### PR TITLE
Update to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4.1-alpine
 
-ENV DANGER_VERSION 5.5.4
+ENV DANGER_VERSION 5.6.2
 
 RUN apk add --no-cache --virtual .gem-build-deps build-base && \
     gem install danger -v $DANGER_VERSION && \


### PR DESCRIPTION
上げれば直るよって言われたので上げる（雑）
```
Use `--` to separate paths from revisions, like this:  
`git \<command\> [\<revision\>...] -- [\<file\>...]`. Updating the Danger gem might fix the issue. Your Danger version: 5.5.4, latest Danger version: 5.6.2
```